### PR TITLE
Add OpenAI environment variable overrides

### DIFF
--- a/src/Explain.Cli.Tests/Configuration/OpenAiConfigurationTests.cs
+++ b/src/Explain.Cli.Tests/Configuration/OpenAiConfigurationTests.cs
@@ -1,0 +1,55 @@
+using Explain.Cli.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Explain.Cli.Tests.Configuration;
+
+[TestClass]
+public class OpenAiConfigurationTests
+{
+    [TestMethod]
+    public void EnvironmentVariables_Override_AppSettings()
+    {
+        var appSettings = new Dictionary<string, string?>
+        {
+            ["OpenAi:ApiKey"] = "json-key",
+            ["OpenAi:ModelName"] = "json-model",
+            ["OpenAi:SmartModelName"] = "json-smart"
+        };
+
+        Environment.SetEnvironmentVariable("EXPLAIN_OPENAI_KEY", "env-key");
+        Environment.SetEnvironmentVariable("EXPLAIN_OPENAI_MODEL_NAME", "env-model");
+        Environment.SetEnvironmentVariable("EXPLAIN_OPENAI_SMART_MODEL_NAME", "env-smart");
+
+        var envOverrides = new Dictionary<string, string?>
+        {
+            ["OpenAi:ApiKey"] = Environment.GetEnvironmentVariable("EXPLAIN_OPENAI_KEY"),
+            ["OpenAi:ModelName"] = Environment.GetEnvironmentVariable("EXPLAIN_OPENAI_MODEL_NAME"),
+            ["OpenAi:SmartModelName"] = Environment.GetEnvironmentVariable("EXPLAIN_OPENAI_SMART_MODEL_NAME")
+        };
+        var sanitizedEnvOverrides = envOverrides
+            .Where(kv => !string.IsNullOrWhiteSpace(kv.Value))
+            .ToDictionary(kv => kv.Key, kv => kv.Value!);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(appSettings!)
+            .AddEnvironmentVariables()
+            .AddInMemoryCollection(sanitizedEnvOverrides)
+            .Build();
+
+        var services = new ServiceCollection();
+        services.Configure<OpenAiOptions>(configuration.GetSection(OpenAiOptions.SectionName));
+        var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<OpenAiOptions>>().Value;
+
+        Assert.AreEqual("env-key", options.ApiKey);
+        Assert.AreEqual("env-model", options.ModelName);
+        Assert.AreEqual("env-smart", options.SmartModelName);
+
+        Environment.SetEnvironmentVariable("EXPLAIN_OPENAI_KEY", null);
+        Environment.SetEnvironmentVariable("EXPLAIN_OPENAI_MODEL_NAME", null);
+        Environment.SetEnvironmentVariable("EXPLAIN_OPENAI_SMART_MODEL_NAME", null);
+    }
+}

--- a/src/Explain.Cli/Program.cs
+++ b/src/Explain.Cli/Program.cs
@@ -32,10 +32,23 @@ class Program
     static ServiceProvider CreateServiceProvider(string[] args)
     {
         // Build configuration
+        var envOverrides = new Dictionary<string, string?>
+        {
+            ["OpenAi:ApiKey"] = Environment.GetEnvironmentVariable("EXPLAIN_OPENAI_KEY"),
+            ["OpenAi:ModelName"] = Environment.GetEnvironmentVariable("EXPLAIN_OPENAI_MODEL_NAME"),
+            ["OpenAi:SmartModelName"] = Environment.GetEnvironmentVariable("EXPLAIN_OPENAI_SMART_MODEL_NAME")
+        };
+
+        // Remove null values so they don't override existing configuration
+        var sanitizedEnvOverrides = envOverrides
+            .Where(kv => !string.IsNullOrWhiteSpace(kv.Value))
+            .ToDictionary(kv => kv.Key, kv => kv.Value!);
+
         var configuration = new ConfigurationBuilder()
             .SetBasePath(Path.GetDirectoryName(typeof(Program).Assembly.Location) ?? Directory.GetCurrentDirectory())
             .AddJsonFile("appsettings.json", optional: false, reloadOnChange: false)
             .AddEnvironmentVariables()
+            .AddInMemoryCollection(sanitizedEnvOverrides)
             .AddCommandLine(args)
             .Build();
 


### PR DESCRIPTION
## Summary
- override OpenAI settings with environment variables `EXPLAIN_OPENAI_*`
- test that environment variables override appsettings

## Testing
- `dotnet test src/Explain.Cli.Tests/Explain.Cli.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68415ba7a5448329b0316c215e1d3b7d