### PR TITLE
Enhance gitignore for .NET artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,12 @@ publish/
 **/*apikey*
 **/*secret*
 **/*.key
+# .NET build results and temporary files
+**/[Bb]in/
+**/[Oo]bj/
+**/[Oo]ut/
+
+# Visual Studio and user-specific files
+.vs/
+*.user
+*.suo


### PR DESCRIPTION
## Summary
- ignore bin/obj/out for .NET builds
- ignore VS specific files
- tested running the CLI with env vars
- ran `dotnet test`

## Testing
- `dotnet run --project src/Explain.Cli -- "What is AI?" --verbose`
- `dotnet test src/Explain.Cli.Tests/Explain.Cli.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68415ffb7580832981bc30b2eda360a7