### PR TITLE
Improve CLI input handling

### DIFF
--- a/src/Explain.Cli.Tests/Commands/Explain/CommandExecutionTests.cs
+++ b/src/Explain.Cli.Tests/Commands/Explain/CommandExecutionTests.cs
@@ -1,0 +1,32 @@
+using Explain.Cli.Commands.Explain;
+
+namespace Explain.Cli.Tests.Commands.Explain;
+
+[TestClass]
+public class CommandExecutionTests
+{
+    [TestMethod]
+    public async Task ProcessInputAsync_CommandExecution_CapturesStdoutAndStderr()
+    {
+        var args = new ExplainArguments { Command = "sh" };
+        args.CommandArguments.AddRange(new[] { "-c", "echo out && echo err 1>&2" });
+
+        var result = await ExplainInputHandler.ProcessInputAsync(args);
+
+        Assert.IsTrue(result.Content.Contains("out"));
+        Assert.IsTrue(result.Content.Contains("err"));
+        Assert.IsTrue(result.HasPipedInput);
+    }
+
+    [TestMethod]
+    public async Task ProcessInputAsync_CommandWithQuestion_FormatsContent()
+    {
+        var args = new ExplainArguments { Command = "sh", Question = "What is this?" };
+        args.CommandArguments.AddRange(new[] { "-c", "echo data" });
+
+        var result = await ExplainInputHandler.ProcessInputAsync(args);
+
+        Assert.IsTrue(result.Content.StartsWith("Question: What is this?"));
+        Assert.IsTrue(result.Content.Contains("data"));
+    }
+}

--- a/src/Explain.Cli.Tests/Commands/Explain/ExplainArgumentParserTests.cs
+++ b/src/Explain.Cli.Tests/Commands/Explain/ExplainArgumentParserTests.cs
@@ -47,4 +47,33 @@ public class ExplainArgumentParserTests
         // Assert
         Assert.AreEqual("What is machine learning?", result.Question);
     }
+
+    [TestMethod]
+    public void ParseArguments_CommandDetected_FirstTokenExecutable()
+    {
+        // Arrange
+        var args = new[] { "ls", "-la" };
+
+        // Act
+        var result = ExplainArgumentParser.ParseArguments(args);
+
+        // Assert
+        Assert.AreEqual("ls", result.Command);
+        CollectionAssert.AreEqual(new[] { "-la" }, result.CommandArguments);
+        Assert.AreEqual(string.Empty, result.Question);
+    }
+
+    [TestMethod]
+    public void ParseArguments_QuestionAndCommand_MixedOrder()
+    {
+        // Arrange
+        var args = new[] { "\"What does this show?\"", "ls" };
+
+        // Act
+        var result = ExplainArgumentParser.ParseArguments(args);
+
+        // Assert
+        Assert.AreEqual("What does this show?", result.Question);
+        Assert.AreEqual("ls", result.Command);
+    }
 }

--- a/src/Explain.Cli/Commands/Explain/ExplainArgumentParser.cs
+++ b/src/Explain.Cli/Commands/Explain/ExplainArgumentParser.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
 namespace Explain.Cli.Commands.Explain
 {
     /// <summary>
@@ -13,14 +18,14 @@ namespace Explain.Cli.Commands.Explain
         public static ExplainArguments ParseArguments(string[] args)
         {
             var result = new ExplainArguments();
-            
+
             if (args == null || args.Length == 0)
             {
                 return result;
             }
 
             var argsList = new List<string>(args);
-            
+
             // Check for verbose flag
             if (argsList.Contains("--verbose"))
             {
@@ -35,14 +40,74 @@ namespace Explain.Cli.Commands.Explain
                 argsList.Remove("--think");
             }
 
-            // The remaining argument should be the question
-            if (argsList.Count > 0)
+            if (argsList.Count == 0)
+                return result;
+
+            // Separate quoted question parts from potential command tokens
+            var questionTokens = new List<string>();
+            var commandTokens = new List<string>();
+            bool inQuote = false;
+            foreach (var token in argsList)
             {
-                // If there are multiple arguments remaining, join them as a single question
-                result.Question = string.Join(" ", argsList).Trim('"', '\'');
+                if (token.StartsWith("\"") || token.StartsWith("'"))
+                    inQuote = true;
+
+                if (inQuote)
+                {
+                    questionTokens.Add(token.Trim('"', '\''));
+                    if (token.EndsWith("\"") || token.EndsWith("'"))
+                        inQuote = false;
+                }
+                else
+                {
+                    commandTokens.Add(token);
+                }
+            }
+
+            if (questionTokens.Count > 0)
+                result.Question = string.Join(" ", questionTokens).Trim();
+
+            if (commandTokens.Count > 0)
+            {
+                if (IsExecutable(commandTokens[0]))
+                {
+                    result.Command = commandTokens[0];
+                    result.CommandArguments.AddRange(commandTokens.Skip(1));
+                }
+                else if (commandTokens.Count > 1 && IsExecutable(commandTokens[^1]))
+                {
+                    result.Command = commandTokens[^1];
+                    result.CommandArguments.AddRange(commandTokens.Take(commandTokens.Count - 1));
+                }
+                else if (string.IsNullOrWhiteSpace(result.Question))
+                {
+                    result.Question = string.Join(" ", commandTokens).Trim('"', '\'');
+                }
             }
 
             return result;
+        }
+
+        private static bool IsExecutable(string token)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+                return false;
+
+            if (File.Exists(token))
+                return true;
+
+            var pathEnv = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+            var paths = pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var path in paths)
+            {
+                var candidate = Path.Combine(path, token);
+                if (File.Exists(candidate))
+                    return true;
+                if (File.Exists(candidate + ".exe"))
+                    return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Explain.Cli/Commands/Explain/ExplainArguments.cs
+++ b/src/Explain.Cli/Commands/Explain/ExplainArguments.cs
@@ -8,5 +8,15 @@ namespace Explain.Cli.Commands.Explain
         public string Question { get; set; } = string.Empty;
         public bool IsVerbose { get; set; } = false;
         public bool ThinkDeep { get; set; } = false;
+
+        /// <summary>
+        /// Optional command to execute when no piped input is provided.
+        /// </summary>
+        public string? Command { get; set; }
+
+        /// <summary>
+        /// Arguments for the command to execute.
+        /// </summary>
+        public List<string> CommandArguments { get; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- parse command arguments and detect executable
- track command info in `ExplainArguments`
- enhance input processing to merge stderr, run commands directly, and extend usage
- update and add tests

## Testing
- `dotnet build src/Explain.Cli/Explain.Cli.csproj -c Debug`
- `dotnet test src/Explain.Cli.Tests/Explain.Cli.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684205a718f8832981de71d1105603ba